### PR TITLE
Update page components for quizzes and results

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -132,8 +132,9 @@ function WordsManager() {
               <thead>
                 <tr className="border-b text-left">
                   <th className="p-2">Kana/Kanji</th>
-                  <th className="p-2">Meaning</th>
-                  <th className="p-2">Pronunciation</th>
+                  <th className="p-2">English</th>
+                  <th className="p-2">English</th>
+                  <th className="p-2">Audio</th>
                   <th className="p-2 w-40">Actions</th>
                 </tr>
               </thead>
@@ -142,15 +143,17 @@ function WordsManager() {
                   <tr key={w.id} className="border-b">
                     <td className="p-2">
                       <div className="font-medium">
-                        {w.hiragana || w.katakana || w.kanji}
+                        {w.hiragana || w.kanji || w.romaji}
+                        {w.hiragana || w.kanji || w.romaji}
                       </div>
                       <div className="text-xs text-muted-foreground">
                         {w.kanji}
                       </div>
                     </td>
-                    <td className="p-2">{w.meaning}</td>
+                    <td className="p-2">{w.english}</td>
+                    <td className="p-2">{w.english}</td>
                     <td className="p-2 truncate max-w-[12rem]">
-                      {w.pronunciation}
+                      {w.pronunciationUrl}
                     </td>
                     <td className="p-2">
                       <div className="flex gap-2">
@@ -219,11 +222,13 @@ function CreateWordDialog({
 }) {
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState<Omit<Word, "id">>({
-    hiragana: "",
-    katakana: "",
     kanji: "",
-    pronunciation: "",
-    meaning: "",
+    hiragana: "",
+    romaji: "",
+    english: "",
+    pronunciationUrl: "",
+    level: "",
+    createdAt: new Date().toISOString(),
   });
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -235,31 +240,12 @@ function CreateWordDialog({
           <DialogTitle>Add Word</DialogTitle>
         </DialogHeader>
         <div className="grid gap-3">
-          <LabeledInput
-            label="Hiragana"
-            value={form.hiragana}
-            onChange={(v) => setForm({ ...form, hiragana: v })}
-          />
-          <LabeledInput
-            label="Katakana"
-            value={form.katakana}
-            onChange={(v) => setForm({ ...form, katakana: v })}
-          />
-          <LabeledInput
-            label="Kanji"
-            value={form.kanji ?? ""}
-            onChange={(v) => setForm({ ...form, kanji: v })}
-          />
-          <LabeledInput
-            label="Pronunciation URL"
-            value={form.pronunciation}
-            onChange={(v) => setForm({ ...form, pronunciation: v })}
-          />
-          <LabeledInput
-            label="Meaning"
-            value={form.meaning}
-            onChange={(v) => setForm({ ...form, meaning: v })}
-          />
+          <LabeledInput label="Kanji" value={form.kanji ?? ""} onChange={(v) => setForm({ ...form, kanji: v })} />
+          <LabeledInput label="Hiragana" value={form.hiragana ?? ""} onChange={(v) => setForm({ ...form, hiragana: v })} />
+          <LabeledInput label="Romaji" value={form.romaji ?? ""} onChange={(v) => setForm({ ...form, romaji: v })} />
+          <LabeledInput label="English" value={form.english} onChange={(v) => setForm({ ...form, english: v })} />
+          <LabeledInput label="Pronunciation URL" value={form.pronunciationUrl ?? ""} onChange={(v) => setForm({ ...form, pronunciationUrl: v })} />
+          <LabeledInput label="Level" value={form.level ?? ""} onChange={(v) => setForm({ ...form, level: v })} />
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>
@@ -303,31 +289,12 @@ function EditWordDialog({
           <DialogTitle>Edit Word</DialogTitle>
         </DialogHeader>
         <div className="grid gap-3">
-          <LabeledInput
-            label="Hiragana"
-            value={form.hiragana ?? ""}
-            onChange={(v) => setForm({ ...form, hiragana: v })}
-          />
-          <LabeledInput
-            label="Katakana"
-            value={form.katakana ?? ""}
-            onChange={(v) => setForm({ ...form, katakana: v })}
-          />
-          <LabeledInput
-            label="Kanji"
-            value={form.kanji ?? ""}
-            onChange={(v) => setForm({ ...form, kanji: v })}
-          />
-          <LabeledInput
-            label="Pronunciation URL"
-            value={form.pronunciation ?? ""}
-            onChange={(v) => setForm({ ...form, pronunciation: v })}
-          />
-          <LabeledInput
-            label="Meaning"
-            value={form.meaning ?? ""}
-            onChange={(v) => setForm({ ...form, meaning: v })}
-          />
+          <LabeledInput label="Kanji" value={form.kanji ?? ""} onChange={(v) => setForm({ ...form, kanji: v })} />
+          <LabeledInput label="Hiragana" value={form.hiragana ?? ""} onChange={(v) => setForm({ ...form, hiragana: v })} />
+          <LabeledInput label="Romaji" value={form.romaji ?? ""} onChange={(v) => setForm({ ...form, romaji: v })} />
+          <LabeledInput label="English" value={form.english ?? ""} onChange={(v) => setForm({ ...form, english: v })} />
+          <LabeledInput label="Pronunciation URL" value={form.pronunciationUrl ?? ""} onChange={(v) => setForm({ ...form, pronunciationUrl: v })} />
+          <LabeledInput label="Level" value={form.level ?? ""} onChange={(v) => setForm({ ...form, level: v })} />
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>
@@ -735,7 +702,7 @@ function CreateQuizDialog({ onCreated }: { onCreated: () => void }) {
                     }
                   />
                   <span>
-                    {w.hiragana || w.katakana || w.kanji} — {w.meaning}
+                    {w.hiragana || w.kanji || w.romaji} — {w.english}
                   </span>
                 </label>
               ))}

--- a/src/app/(app)/quizzes/[id]/page.tsx
+++ b/src/app/(app)/quizzes/[id]/page.tsx
@@ -88,15 +88,16 @@ export default function QuizTakingPage() {
                   <div className="border rounded-md p-4 space-y-2">
                     <div className="text-2xl font-semibold">
                       {words[index].word.hiragana ||
-                        words[index].word.katakana ||
-                        words[index].word.kanji}
+                        words[index].word.kanji ||
+                        words[index].word.romaji}
                     </div>
-                    {words[index].word.pronunciation && (
+                    {words[index].word.pronunciationUrl && (
                       <Button
                         variant="ghost"
                         size="sm"
                         onClick={() =>
-                          new Audio(words[index].word.pronunciation)
+                          words[index].word.pronunciationUrl &&
+                          new Audio(words[index].word.pronunciationUrl)
                             .play()
                             .catch(() => {})
                         }
@@ -106,7 +107,7 @@ export default function QuizTakingPage() {
                       </Button>
                     )}
                     <div className="text-sm text-muted-foreground">
-                      Meaning?
+                      English?
                     </div>
                     <Input
                       value={answers[words[index].wordId] ?? ""}

--- a/src/app/(app)/quizzes/create/page.tsx
+++ b/src/app/(app)/quizzes/create/page.tsx
@@ -115,7 +115,7 @@ export default function QuizCreationPage() {
                         onCheckedChange={() => toggle(w.id)}
                       />
                       <span className="text-sm">
-                        {w.hiragana || w.katakana || w.kanji} — {w.meaning}
+                        {w.hiragana || w.kanji || w.romaji} — {w.english}
                       </span>
                     </label>
                   ))}

--- a/src/app/(app)/results/[attemptId]/page.tsx
+++ b/src/app/(app)/results/[attemptId]/page.tsx
@@ -66,12 +66,10 @@ export default function QuizResultsPage() {
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <div className="text-lg font-semibold">
-                      {item.word.hiragana ||
-                        item.word.katakana ||
-                        item.word.kanji}
+                      {item.word.hiragana || item.word.kanji || item.word.romaji}
                     </div>
                     <div className="text-sm text-muted-foreground">
-                      Meaning: {item.word.meaning}
+                      English: {item.word.english}
                     </div>
                     <div className="text-sm mt-1">
                       Your answer:{" "}

--- a/src/app/(app)/words/page.tsx
+++ b/src/app/(app)/words/page.tsx
@@ -97,7 +97,7 @@ function filterWords(words: Word[], q: string) {
   const s = q.trim().toLowerCase();
   if (!s) return words;
   return words.filter((w) =>
-    [w.meaning, w.hiragana, w.katakana, w.kanji ?? ""].some((v) =>
+    [w.english, w.hiragana, w.romaji, w.kanji ?? "", w.level ?? ""].some((v) =>
       v?.toLowerCase().includes(s)
     )
   );
@@ -145,11 +145,10 @@ function Flashcard({ word }: { word: Word }) {
   const playAudio = useCallback(
     async (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (!word.pronunciation || isPlaying) return;
-
+      if (!word.pronunciationUrl || isPlaying) return;
       setIsPlaying(true);
       try {
-        const audio = new Audio(word.pronunciation);
+        const audio = new Audio(word.pronunciationUrl);
         audio.onended = () => setIsPlaying(false);
         audio.onerror = () => setIsPlaying(false);
         await audio.play();
@@ -157,7 +156,7 @@ function Flashcard({ word }: { word: Word }) {
         setIsPlaying(false);
       }
     },
-    [word.pronunciation, isPlaying]
+    [word.pronunciationUrl, isPlaying]
   );
 
   return (
@@ -175,18 +174,14 @@ function Flashcard({ word }: { word: Word }) {
           <Card className="h-full border-2 border-transparent hover:border-primary/30 transition-all duration-300 hover:shadow-lg hover:shadow-primary/10 bg-gradient-to-br from-white to-slate-50 dark:from-slate-800 dark:to-slate-900">
             <CardContent className="h-full flex flex-col justify-center items-center p-6 space-y-3">
               <div className="text-center space-y-2">
-                <div className="text-3xl font-bold text-primary">
-                  {word.hiragana || word.katakana || word.kanji}
-                </div>
+                <div className="text-3xl font-bold text-primary">{word.hiragana || word.kanji || word.romaji}</div>
                 {word.kanji && word.hiragana && (
                   <div className="text-xl text-slate-600 dark:text-slate-300">
                     {word.kanji}
                   </div>
                 )}
               </div>
-              <Badge variant="secondary" className="text-xs opacity-70">
-                Click to reveal meaning
-              </Badge>
+              <Badge variant="secondary" className="text-xs opacity-70">Click to reveal English</Badge>
             </CardContent>
           </Card>
         </div>
@@ -196,19 +191,13 @@ function Flashcard({ word }: { word: Word }) {
           <Card className="h-full border-2 border-green-200 dark:border-green-800 bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20">
             <CardContent className="h-full flex flex-col justify-center items-center p-6 space-y-4">
               <div className="text-center space-y-3">
-                <div className="text-xl font-semibold text-green-800 dark:text-green-200">
-                  {word.meaning}
-                </div>
-                <div className="text-lg text-slate-700 dark:text-slate-300">
-                  {word.hiragana || word.katakana || word.kanji}
-                </div>
+                <div className="text-xl font-semibold text-green-800 dark:text-green-200">{word.english}</div>
+                <div className="text-lg text-slate-700 dark:text-slate-300">{word.hiragana || word.kanji || word.romaji}</div>
                 {word.kanji && word.hiragana && (
-                  <div className="text-sm text-slate-500 dark:text-slate-400">
-                    {word.kanji}
-                  </div>
+                  <div className="text-sm text-slate-500 dark:text-slate-400">{word.kanji}</div>
                 )}
               </div>
-              {word.pronunciation && (
+              {word.pronunciationUrl && (
                 <Button
                   variant="outline"
                   size="sm"

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -18,14 +18,15 @@ export type Pagination = {
   totalPages: number
 }
 
-// Words
 export type Word = {
   id: string
-  hiragana: string
-  katakana: string
   kanji: string | null
-  pronunciation: string
-  meaning: string
+  hiragana: string
+  romaji: string | null
+  english: string
+  pronunciationUrl: string
+  level: string | null
+  createdAt: string
 }
 
 export type WordsListResponse = {


### PR DESCRIPTION
Revise components to reflect changes in word attributes, replacing 'meaning' with 'english' and adding 'romaji' where applicable. Adjust forms and dialogs to accommodate the new structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CSV import now auto-refreshes stats for up to 30 seconds post-upload.
  - Audio playback uses a pronunciation URL when available.
  - Added Level support for words and filtering.

- Refactor
  - Vocabulary UI now uses English and Romaji instead of Meaning and Katakana.
  - Labels updated from “Meaning” to “English” across quizzes, results, and words.
  - Display prioritizes Kanji/Hiragana/Romaji; flashcards and quizzes mirror this.
  - Create/Edit word dialogs restructured: Kanji, Hiragana, Romaji, English, Pronunciation URL, Level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->